### PR TITLE
Removing stale split_by_character reference

### DIFF
--- a/minirag/minirag.py
+++ b/minirag/minirag.py
@@ -484,8 +484,6 @@ class MiniRAG:
                     }
                     for dp in self.chunking_func(
                         status_doc.content,
-                        split_by_character,
-                        split_by_character_only,
                         self.chunk_overlap_token_size,
                         self.chunk_token_size,
                         self.tiktoken_model_name,


### PR DESCRIPTION
It appears the split_by_character error about 6 things being passed despite the function requiring 4 is still present.



This commit was supposed to fix it:
https://github.com/HKUDS/MiniRAG/commit/e7db2be075c220c4937dd8bbf3ff90b4023e66de



However it is still here https://github.com/HKUDS/MiniRAG/blob/5f677cc579005f330391398a1261495ba2bed37b/minirag/minirag.py#L487
