### PR TITLE
Fix: Packaging: Sub-packages kg, llm, api.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "minirag-hku"
-version = "0.0.2"
+version = "0.0.3"
 authors = [
     {name = "Tianyu Fan"},
 ]
@@ -19,6 +19,3 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-
-[tool.setuptools]
-packages = ["minirag"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "minirag-hku"
-version = "0.0.3"
+version = "0.0.2"
 authors = [
     {name = "Tianyu Fan"},
 ]


### PR DESCRIPTION
To get the sub-packages correctly installed. The `[tool.setuptools]` section from `pyproject.toml` shall be removed. 

This forces the build backend to rely solely on the `packages=setuptools.find_packages(...)` configuration defined in `setup.py`, which makes the software works as expected.

Fix #78, fix #55.