### PR TITLE
Add Weaviate-based vector, KV, and graph storage

### DIFF
--- a/minirag/kg/weaviate_impl.py
+++ b/minirag/kg/weaviate_impl.py
@@ -1,0 +1,261 @@
+import asyncio
+from typing import Any, Union, List, Set, Dict
+import weaviate
+from weaviate.exceptions import WeaviateQueryException
+from dataclasses import dataclass, field
+from minirag.base import (
+    BaseVectorStorage,
+    BaseKVStorage,
+    BaseGraphStorage
+)
+
+async def run_sync(func, *args, **kwargs):
+    return await asyncio.to_thread(func, *args, **kwargs)
+
+@dataclass
+class WeaviateVectorStorage(BaseVectorStorage):
+    client: weaviate.Client = field(init=False)
+
+    def __post_init__(self):
+        self.client = weaviate.Client(url="http://localhost:8080")
+        self.init_schema()
+        # We assume `namespace` holds the weaviate URL
+    def init_schema(self):
+        try:
+            if not self.client.schema.contains({"class": "Document"}):
+                self.client.schema.create_class({
+                    "class": "Document",
+                    "properties": [{"name": "content", "dataType": ["text"]}],
+                })
+        except WeaviateQueryException as e:
+            print(f"Vector schema init error: {e}")
+
+    async def query(self, query: str, top_k: int) -> List[Dict]:
+        try:
+            near_text = {"concepts": [query]}
+            response = await run_sync(
+                self.client.query.get, "Document", ["content"]
+            )
+            response = (
+                self.client.query.get("Document", ["content"])
+                .with_near_text(near_text)
+                .with_limit(top_k)
+                .do()
+            )
+            return response.get("data", {}).get("Get", {}).get("Document", [])
+        except WeaviateQueryException as e:
+            print(f"Weaviate query error: {e}")
+            return []
+
+    async def upsert(self, data: Dict[str, Dict]):
+        # data: {id: {content: str, embedding: list[float], ...}}
+        for _id, value in data.items():
+            try:
+                # Weaviate expects data objects for upsert
+                obj = {
+                    "content": value.get("content"),
+                }
+                await run_sync(
+                    self.client.data_object.create, obj, "Document", _id
+                )
+            except WeaviateQueryException as e:
+                print(f"Error upserting id {_id} to weaviate: {e}")
+
+    async def delete(self, ids: List[str]):
+        for _id in ids:
+            try:
+                await run_sync(self.client.data_object.delete, _id, "Document")
+            except WeaviateQueryException as e:
+                print(f"Error deleting id {_id}: {e}")
+
+    async def clear(self):
+        try:
+            await run_sync(self.client.batch.delete_objects, class_name="Document")
+        except WeaviateQueryException as e:
+            print(f"Vector clear failed: {e}")
+
+    async def count(self) -> int:
+        try:
+            result = await run_sync(
+                self.client.query.aggregate("Document").with_meta_count().do
+            )
+            return result["data"]["Aggregate"]["Document"][0]["meta"]["count"]
+        except WeaviateQueryException as e:
+            print(f"Count failed: {e}")
+            return 0
+
+@dataclass
+class WeaviateKVStorage(BaseKVStorage):
+    client: weaviate.Client = field(init=False)
+
+    def __post_init__(self):
+        self.client = weaviate.Client(url="http://localhost:8080")
+        self.init_schema()
+
+    async def all_keys(self) -> List[str]:
+        try:
+            response = await run_sync(lambda: self.client.query.get("KVDocument", ["_id"]).do())
+            results = response.get("data", {}).get("Get", {}).get("KVDocument", [])
+            return [item["_id"] for item in results]
+        except WeaviateQueryException as e:
+            print(f"Weaviate all_keys error: {e}")
+            return []
+
+    async def get_by_id(self, id: str) -> Union[Dict, None]:
+        try:
+            obj = await run_sync(self.client.data_object.get, id, "KVDocument")
+            return obj.get("properties", None)
+        except WeaviateQueryException as e:
+            print(f"Weaviate get_by_id error for {id}: {e}")
+            return None
+
+    async def get_by_ids(self, ids: List[str], fields: Union[Set[str], None] = None) -> List[Union[Dict, None]]:
+        results = []
+        for _id in ids:
+            data = await self.get_by_id(_id)
+            if data and fields:
+                data = {k: v for k, v in data.items() if k in fields}
+            results.append(data)
+        return results
+
+    async def filter_keys(self, data: List[str]) -> Set[str]:
+        existing_keys = set(await self.all_keys())
+        return set(data) - existing_keys
+
+    async def upsert(self, data: Dict[str, Dict]):
+        for _id, value in data.items():
+            try:
+                await run_sync(
+                    self.client.data_object.create, value, "KVDocument", _id
+                )
+            except WeaviateQueryException as e:
+                print(f"Error upserting KV id {_id}: {e}")
+
+    async def delete(self, ids: List[str]):
+        for _id in ids:
+            try:
+                await run_sync(self.client.data_object.delete, _id, "KVDocument")
+            except WeaviateQueryException as e:
+                print(f"Error deleting KV id {_id}: {e}")
+
+    def init_schema(self):
+        try:
+            if not self.client.schema.contains({"class": "KVDocument"}):
+                self.client.schema.create_class({
+                    "class": "KVDocument",
+                    "properties": [{"name": "key", "dataType": ["text"]}]
+                })
+        except WeaviateQueryException as e:
+            print(f"KV schema init error: {e}")
+
+    async def clear(self):
+        try:
+            await run_sync(self.client.batch.delete_objects, class_name="KVDocument")
+        except WeaviateQueryException as e:
+            print(f"KV clear failed: {e}")
+
+    async def count(self) -> int:
+        try:
+            result = await run_sync(lambda: self.client.query.aggregate("KVDocument").with_meta_count().do())
+            return result["data"]["Aggregate"]["KVDocument"][0]["meta"]["count"]
+        except WeaviateQueryException as e:
+            print(f"KV count failed: {e}")
+            return 0
+        
+@dataclass
+class WeaviateGraphStorage(BaseGraphStorage):
+    client: weaviate.Client = field(init=False)
+
+    def __post_init__(self):
+        self.client = weaviate.Client(url="http://localhost:8080")
+        self.init_schema()
+
+    async def get_types(self) -> tuple[List[str], List[str]]:
+        # Returns (list of node classes, list of edge classes)
+        try:
+            schema = await run_sync(self.client.schema.get)
+            classes = schema.get("classes", [])
+            node_classes = [cls["class"] for cls in classes]
+            # Weaviate edges are references inside properties, so edge classes uncommon
+            edge_classes = []
+            return node_classes, edge_classes
+        except WeaviateQueryException as e:
+            print(f"Weaviate get_types error: {e}")
+            return [], []
+
+    async def has_node(self, node_id: str) -> bool:
+        try:
+            obj = await run_sync(self.client.data_object.exists, node_id, None)
+            return obj
+        except WeaviateQueryException as e:
+            print(f"Error checking node {node_id}: {e}")
+            return False
+
+    async def has_edge(self, source_node_id: str, target_node_id: str) -> bool:
+        # Weaviate edges are references; this is complex, simplified here
+        return False
+
+    async def node_degree(self, node_id: str) -> int:
+        # Not trivial in Weaviate, returning 0 or implement with custom query
+        return 0
+
+    async def edge_degree(self, src_id: str, tgt_id: str) -> int:
+        return 0
+
+    async def get_node(self, node_id: str) -> Union[Dict, None]:
+        try:
+            obj = await run_sync(self.client.data_object.get, node_id)
+            return obj.get("properties", None)
+        except WeaviateQueryException as e:
+            print(f"Error getting node {node_id}: {e}")
+            return None
+
+    async def get_edge(self, source_node_id: str, target_node_id: str) -> Union[Dict, None]:
+        return None
+
+    async def get_node_edges(self, source_node_id: str) -> Union[List[tuple], None]:
+        return None
+
+    async def upsert_node(self, node_id: str, node_data: Dict[str, str]):
+        try:
+            await run_sync(self.client.data_object.create, node_data, "GraphNode", node_id)
+        except WeaviateQueryException as e:
+            print(f"Error upserting node {node_id}: {e}")
+    def init_schema(self):
+        try:
+            if not self.client.schema.contains({"class": "GraphNode"}):
+                self.client.schema.create_class({
+                    "class": "GraphNode",
+                    "properties": [
+                        {"name": "name", "dataType": ["text"]},
+                        {"name": "linkedTo", "dataType": ["GraphNode"]}  # For references
+                    ]
+                })
+        except WeaviateQueryException as e:
+            print(f"Graph schema init error: {e}")
+
+    async def clear(self):
+        try:
+            await run_sync(self.client.batch.delete_objects, class_name="GraphNode")
+        except WeaviateQueryException as e:
+            print(f"Graph clear failed: {e}")
+
+    async def upsert_edge(self, source_node_id: str, target_node_id: str, edge_data: Dict[str, str]):
+        try:
+            await run_sync(
+                self.client.data_object.add_reference,
+                from_object_uuid=source_node_id,
+                from_property="linkedTo",
+                to_object_uuid=target_node_id
+            )
+        except WeaviateQueryException as e:
+            print(f"Edge creation failed: {e}")
+
+    async def delete_node(self, node_id: str):
+        try:
+            await run_sync(self.client.data_object.delete, node_id, "GraphNode")
+        except WeaviateQueryException as e:
+            print(f"Error deleting node {node_id}: {e}")
+
+    async def embed_nodes(self, algorithm: str):
+        raise NotImplementedError("Node embedding not implemented for Weaviate.")

--- a/minirag/minirag.py
+++ b/minirag/minirag.py
@@ -59,6 +59,10 @@ STORAGES = {
     "PGGraphStorage": ".kg.postgres_impl",
     "GremlinStorage": ".kg.gremlin_impl",
     "PGDocStatusStorage": ".kg.postgres_impl",
+    "WeaviateVectorStorage": ".kg.weaviate_impl",
+    "WeaviateKVStorage": ".kg.weaviate_impl",
+    "WeaviateGraphStorage": ".kg.weaviate_impl",
+    "run_sync": ".kg.weaviate_impl",
 }
 
 # future KG integrations

--- a/tests/test_weaviate.py
+++ b/tests/test_weaviate.py
@@ -1,0 +1,260 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from weaviate.exceptions import WeaviateQueryException
+from minirag.kg.weaviate_impl import (
+    run_sync,
+    WeaviateVectorStorage,
+    WeaviateKVStorage,
+    WeaviateGraphStorage,
+)
+
+@pytest.mark.asyncio
+async def test_run_sync():
+    def sync_function(x):
+        return x * 2
+    result = await run_sync(sync_function, 5)
+    assert result == 10
+
+def mock_weaviate_client():
+    client = MagicMock()
+    client.schema.contains.return_value = False
+    client.schema.create_class.return_value = None
+    client.data_object.create = MagicMock()
+    client.data_object.delete = MagicMock()
+    client.data_object.get = MagicMock(return_value={"properties": {"foo": "bar"}})
+    client.data_object.exists = MagicMock(return_value=True)
+    client.data_object.add_reference = MagicMock()
+
+    # Vector storage
+    client.query.get.return_value.with_near_text.return_value.with_limit.return_value.do.return_value = {
+        "data": {"Get": {"Document": [{"content": "hello"}]}}
+    }
+
+    # Count
+    client.query.aggregate.return_value.with_meta_count.return_value.do.return_value = {
+        "data": {"Aggregate": {"Document": [{"meta": {"count": 2}}]}}
+    }
+
+    client.batch.delete_objects = MagicMock()
+    client.schema.get.return_value = {"classes": [{"class": "GraphNode"}]}
+
+    return client
+
+# === VECTOR STORAGE ===
+@pytest.mark.asyncio
+@patch("minirag.kg.weaviate_impl.weaviate.Client")
+async def test_vector_storage_methods(mock_client_class):
+    mock_client = MagicMock()
+    mock_client_class.return_value = mock_client
+
+    dummy_global_config = MagicMock()
+    dummy_embedding_func = MagicMock()
+
+    # Mock schema check
+    mock_client.schema.contains.return_value = False
+    mock_client.schema.create_class.return_value = None
+
+    # Setup query chain mock: get().with_near_text().with_limit().do()
+    mock_do = MagicMock()
+    mock_do.return_value = {
+        "data": {"Get": {"Document": [{"content": "hello"}]}}
+    }
+    mock_with_limit = MagicMock()
+    mock_with_limit.do = mock_do
+    mock_with_near_text = MagicMock()
+    mock_with_near_text.with_limit.return_value = mock_with_limit
+    mock_get = MagicMock()
+    mock_get.with_near_text.return_value = mock_with_near_text
+    mock_client.query.get.return_value = mock_get
+
+    # Mock aggregate().with_meta_count().do()
+    mock_agg_do = MagicMock()
+    mock_agg_do.do.return_value = {
+        "data": {
+            "Aggregate": {
+                "Document": [
+                    {"meta": {"count": 2}}
+                ]
+            }
+        }
+    }
+
+    mock_agg = MagicMock()
+    mock_agg.with_meta_count.return_value = mock_agg_do
+    mock_client.query.aggregate.return_value = mock_agg
+
+    vec = WeaviateVectorStorage(
+        namespace="dummy", 
+        global_config=dummy_global_config, 
+        embedding_func=dummy_embedding_func
+    )
+
+    # Test upsert
+    await vec.upsert({"doc1": {"content": "hello"}})
+    mock_client.data_object.create.assert_called_with({"content": "hello"}, "Document", "doc1")
+
+    # Test query
+    results = await vec.query("hello", top_k=1)
+    assert results == [{"content": "hello"}]
+
+    # Test delete
+    await vec.delete(["doc1"])
+    mock_client.data_object.delete.assert_called_with("doc1", "Document")
+
+    # Test clear
+    await vec.clear()
+    mock_client.batch.delete_objects.assert_called_with(class_name="Document")
+
+    # Test count
+    count = await vec.count()
+    assert count == 2
+
+    # Test schema init
+    mock_client.schema.contains.assert_called_with({"class": "Document"})
+    mock_client.schema.create_class.assert_called()
+
+# === KV STORAGE ===
+
+@pytest.mark.asyncio
+@patch("minirag.kg.weaviate_impl.weaviate.Client")
+async def test_kv_storage_all_methods(mock_client_class):
+    mock_client = mock_weaviate_client()
+    mock_client_class.return_value = mock_client
+
+    dummy_global_config = MagicMock()
+    dummy_embedding_func = MagicMock()
+
+    kv = WeaviateKVStorage(namespace="dummy", 
+                           global_config=dummy_global_config, 
+                           embedding_func=dummy_embedding_func)
+
+    # get_by_id
+    result = await kv.get_by_id("key1")
+    assert result == {"foo": "bar"}
+
+    # get_by_ids
+    results = await kv.get_by_ids(["key1", "key2"], fields={"foo"})
+    assert results == [{"foo": "bar"}, {"foo": "bar"}]
+
+    # all_keys
+    mock_do = MagicMock()
+    mock_do.return_value = {
+        "data": {"Get": {"KVDocument": [{"_id": "1"}, {"_id": "2"}]}}
+    }
+
+    mock_with_fields = MagicMock()
+    mock_with_fields.do = mock_do
+
+    mock_with_additional = MagicMock()
+    mock_with_additional.with_fields.return_value = mock_with_fields
+
+    mock_get = MagicMock()
+    mock_get.do.return_value = {
+        "data": {"Get": {"KVDocument": [{"_id": "1"}, {"_id": "2"}]}}
+    }
+    mock_client.query.get.return_value = mock_get
+
+    keys = await kv.all_keys()
+    assert keys == ["1", "2"]
+
+    # filter_keys
+    filtered = await kv.filter_keys(["1", "3"])
+    assert filtered == {"3"}
+
+    # upsert
+    await kv.upsert({"k1": {"key": "value"}})
+    mock_client.data_object.create.assert_called()
+
+    # delete
+    await kv.delete(["k1"])
+    mock_client.data_object.delete.assert_called()
+
+    # clear
+    await kv.clear()
+    mock_client.batch.delete_objects.assert_called()
+
+    # count
+    mock_count_do = MagicMock(return_value={
+        "data": {"Aggregate": {"KVDocument": [{"meta": {"count": 5}}]}}
+    })
+    mock_with_meta = MagicMock()
+    mock_with_meta.do = mock_count_do
+    mock_aggregate = MagicMock()
+    mock_aggregate.with_meta_count.return_value = mock_with_meta
+    mock_client.query.aggregate.return_value = mock_aggregate
+    mock_client.schema.contains.return_value = False
+    kv.init_schema()
+    mock_client.schema.create_class.assert_called_with({
+        "class": "KVDocument",
+        "properties": [{"name": "key", "dataType": ["text"]}]
+    })
+
+    count = await kv.count()
+    assert count == 5
+
+# === GRAPH STORAGE ===
+
+@pytest.mark.asyncio
+@patch("minirag.kg.weaviate_impl.weaviate.Client")
+async def test_graph_storage_all_methods(mock_client_class):
+    mock_client = mock_weaviate_client()
+    mock_client_class.return_value = mock_client
+
+    dummy_global_config = MagicMock()
+
+    graph = WeaviateGraphStorage(namespace="dummy", 
+                                 global_config=dummy_global_config)
+        # init_schema
+    mock_client.schema.contains.return_value = False
+    graph.init_schema()
+    mock_client.schema.create_class.assert_called_with({
+        "class": "GraphNode",
+        "properties": [
+            {"name": "name", "dataType": ["text"]},
+            {"name": "linkedTo", "dataType": ["GraphNode"]}
+        ]
+    })
+
+
+    # get_types
+    node_types, edge_types = await graph.get_types()
+    assert "GraphNode" in node_types
+    assert edge_types == []
+
+    # has_node
+    assert await graph.has_node("node1") is True
+
+    # has_edge
+    assert await graph.has_edge("a", "b") is False
+
+    # node_degree and edge_degree
+    assert await graph.node_degree("n1") == 0
+    assert await graph.edge_degree("a", "b") == 0
+
+    # get_node
+    result = await graph.get_node("node1")
+    assert result == {"foo": "bar"}
+
+    # get_edge and get_node_edges
+    assert await graph.get_edge("a", "b") is None
+    assert await graph.get_node_edges("a") is None
+
+    # upsert_node
+    await graph.upsert_node("nodeX", {"name": "hello"})
+    mock_client.data_object.create.assert_called()
+
+    # upsert_edge
+    await graph.upsert_edge("nodeX", "nodeY", {})
+    mock_client.data_object.add_reference.assert_called()
+
+    # delete_node
+    await graph.delete_node("nodeX")
+    mock_client.data_object.delete.assert_called()
+
+    # clear
+    await graph.clear()
+    mock_client.batch.delete_objects.assert_called()
+
+    # embed_nodes
+    with pytest.raises(NotImplementedError):
+        await graph.embed_nodes("dummy-algo")


### PR DESCRIPTION
**### Add Weaviate-based Implementations for Vector, KV, and Graph Storage**
**Overview**

This PR introduces complete support for Weaviate as a backend to MiniRAG’s core storage abstractions, enabling users to leverage a powerful vector-native database with native support for relationships and semantic search.

**What’s Included**
**Vector Storage (WeaviateVectorStorage):**
Implements upsert, query, delete, count, and clear operations using the Document class and Weaviate’s near-text search.

**Key-Value Storage (WeaviateKVStorage):**
Enables efficient key-based reads/writes using KVDocument, with support for get_by_id, all_keys, filter_keys, and more.

**Graph Storage (WeaviateGraphStorage):**
Adds basic graph node/edge support using GraphNode with linkedTo relationships. Includes node upsert, edge creation, degree queries, and schema bootstrapping.

**Tests:**
Added thorough unit tests with pytest and unittest.mock, achieving solid coverage of implemented functionality.

**Key Benefits**
Unified async-compatible design using a run_sync utility.

Modular and pluggable — follows the existing MiniRAG interface patterns.

Built for RAG + KG — combines vector and graph capabilities for hybrid workflows.